### PR TITLE
Allow to set the location of the includes and libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .nadconfig.mk
 build
+deps/
+npm-debug.log

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,18 +9,19 @@
             ['OS!="win"', {
                 'variables':
                 {
-                    'fuse_includes%' : '<!(pkg-config fuse --cflags-only-I | sed s/-I//g)',
-                    'fuse_libraries%': '',
+                    'fuse__include_dirs%': '<!(pkg-config fuse --cflags-only-I | sed s/-I//g)',
+                    'fuse__library_dirs%': '',
+                    'fuse__libraries%'   : '<!(pkg-config --libs-only-L --libs-only-l fuse)',
                 },
                 "include_dirs": [
-                    "<@(fuse_includes)"
+                    "<@(fuse__include_dirs)"
                 ],
                 'library_dirs': [
-                  '<@(fuse_libraries)',
+                  '<@(fuse__library_dirs)',
                 ],
                 "link_settings": {
                     "libraries": [
-                        "-lfuse"
+                        "<@(fuse__libraries)"
                     ]
                 }
             }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,12 +7,20 @@
         ],
         "conditions": [
             ['OS!="win"', {
+                'variables':
+                {
+                    'fuse_includes%' : '<!(pkg-config fuse --cflags-only-I | sed s/-I//g)',
+                    'fuse_libraries%': '',
+                },
                 "include_dirs": [
-                    "<!@(pkg-config fuse --cflags-only-I | sed s/-I//g)"
+                    "<@(fuse_includes)"
+                ],
+                'library_dirs': [
+                  '<@(fuse_libraries)',
                 ],
                 "link_settings": {
                     "libraries": [
-                        "<!@(pkg-config --libs-only-L --libs-only-l fuse)"
+                        "-lfuse"
                     ]
                 }
             }],


### PR DESCRIPTION
This allow to explicitly set the location of the FUSE includes and shared library, specially useful for cross-compile environments like NodeOS.