### PR TITLE
README: suggest catching errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fuse.mount('./mnt', {
 
 process.on('SIGINT', function () {
   fuse.unmount('./mnt', function (err) {
-    if (err) return console.error(err)
+    if (err) throw err
     
     process.exit()
   })

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ fuse.mount('./mnt', {
 })
 
 process.on('SIGINT', function () {
-  fuse.unmount('./mnt', function () {
+  fuse.unmount('./mnt', function (err) {
+    if (err) return console.error(err)
+    
     process.exit()
   })
 })


### PR DESCRIPTION
This caught me when playing with the example,  I left a resource using `./mnt`,  and I had to use `fusermount` to clean it up manually.

**edit: you should probably do this for `.mount` too