### PR TITLE
upgrade nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "gypfile": true,
   "dependencies": {
-    "nan": "^2.3.5",
+    "nan": "^2.11.1",
     "node-gyp-build": "^3.2.2",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
The current version of nan has an issue with Node v10 (now the latest LTS as of 2018-10-30) (https://github.com/nodejs/nan/issues/766)

The latest nan seems to work properly (tho I am still testing a bit more).